### PR TITLE
Add option to assign existing users to the privileged docker user group.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ The machine needs to be prepared. In CI this is done using `molecule/default/pre
 
 Also see a [full explanation and example](https://robertdebock.nl/how-to-use-these-roles.html) on how to use these roles.
 
+## [Role Variables](#role-variables)
+
+The default values for the variables are set in `defaults/main.yml`:
+```yaml
+---
+# defaults file for docker
+
+# Add users to the privileged docker group. For example:
+# docker_privileged_users:
+#  - UserA
+#  - UserB
+docker_privileged_users:
+```
 
 ## [Requirements](#requirements)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+# defaults file for docker
+
+# Add users to the privileged docker group. For example:
+# docker_privileged_users:
+#  - UserA
+#  - UserB
+docker_privileged_users:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -6,3 +6,16 @@
 
   roles:
     - role: ansible-role-docker
+      docker_privileged_users:
+        - woody
+        - buzz
+
+  tasks:
+    - name: Create test case users
+      user:
+        name: "{{ user }}"
+      loop:
+        - woody
+        - buzz
+      loop_control:
+        loop_var: user

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -5,6 +5,16 @@
   gather_facts: no
 
   tasks:
+    - name: Check docker group configuration
+      lineinfile:
+        path: /etc/group
+        regex: '^docker:x:\d*:woody,buzz$'
+        state: absent
+      check_mode: yes
+      register: docker_group
+      changed_when: not docker_group is changed
+      failed_when: docker_group is changed
+
     - name: create a container
       docker_container:
         name: openssh

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,10 +11,21 @@
     name: "{{ docker_pip_packages }}"
     state: present
 
-- name: add docker group
+- name: create privileged docker user group
   ansible.builtin.group:
     name: docker
-    system: yes
+    state: present
+
+- name: add privileged users to the docker user group
+  user:
+    name: "{{ user }}"
+    groups: docker
+    append: yes
+  loop: "{{ docker_privileged_users }}"
+  loop_control:
+    loop_var: user
+  when:
+    - docker_privileged_users | length
 
 - name: start and enable docker
   ansible.builtin.service:


### PR DESCRIPTION
Add option to assign existing users to the privileged docker user group.
---

**Description**
This PR provides the ability to assign existing users to the Docker privileged user group ([see official docs](https://docs.docker.com/engine/install/linux-postinstall/)).

**Testing**
New test case created.